### PR TITLE
Upgraded `hotels-oss-parent` to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [TBD] - TBD
+### Changed
+* Upgraded `hotels-oss-parent` to 4.1.0 (was 2.0.6).
+
 ## [1.0.2] - 2018-10-23
 ### Added
 * SshSettings has a new parameter that can be assigned: localhost.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.0.6</version>
+    <version>4.1.0</version>
   </parent>
 
   <artifactId>hcommon-ssh</artifactId>
@@ -20,6 +20,7 @@
   </scm>
 
   <properties>
+    <jdk.version>1.7</jdk.version>
     <jsch.version>0.1.54</jsch.version>
     <jsch-extension.version>0.1.6</jsch-extension.version>
     <validation-api.version>1.1.0.Final</validation-api.version>

--- a/src/main/java/com/hotels/hcommon/ssh/MethodChecker.java
+++ b/src/main/java/com/hotels/hcommon/ssh/MethodChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/SshException.java
+++ b/src/main/java/com/hotels/hcommon/ssh/SshException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/SshSettings.java
+++ b/src/main/java/com/hotels/hcommon/ssh/SshSettings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/Tunnelable.java
+++ b/src/main/java/com/hotels/hcommon/ssh/Tunnelable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/TunnelableFactory.java
+++ b/src/main/java/com/hotels/hcommon/ssh/TunnelableFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/TunnelableSupplier.java
+++ b/src/main/java/com/hotels/hcommon/ssh/TunnelableSupplier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/session/DefaultSessionFactorySupplier.java
+++ b/src/main/java/com/hotels/hcommon/ssh/session/DefaultSessionFactorySupplier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactory.java
+++ b/src/main/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryBuilder.java
+++ b/src/main/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/session/SessionFactorySupplier.java
+++ b/src/main/java/com/hotels/hcommon/ssh/session/SessionFactorySupplier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/tunnel/DefaultTunnelConnectionManagerFactory.java
+++ b/src/main/java/com/hotels/hcommon/ssh/tunnel/DefaultTunnelConnectionManagerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/tunnel/TunnelConnectionManagerFactory.java
+++ b/src/main/java/com/hotels/hcommon/ssh/tunnel/TunnelConnectionManagerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/validation/Preconditions.java
+++ b/src/main/java/com/hotels/hcommon/ssh/validation/Preconditions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/validation/constraint/TunnelRoute.java
+++ b/src/main/java/com/hotels/hcommon/ssh/validation/constraint/TunnelRoute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/hotels/hcommon/ssh/validation/validator/TunnelRouteValidator.java
+++ b/src/main/java/com/hotels/hcommon/ssh/validation/validator/TunnelRouteValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/SshSettingsTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/SshSettingsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/TunnelableFactoryTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/TunnelableFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/session/DefaultSessionFactorySupplierTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/session/DefaultSessionFactorySupplierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryBuilderTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,7 +60,14 @@ public class DelegatingSessionFactoryBuilderTest {
 
   @Test
   public void verifyNumberOfMethods() throws Exception {
-    assertThat(SessionFactoryBuilder.class.getDeclaredMethods().length, is(6));
+    Method[] declaredMethods = SessionFactoryBuilder.class.getDeclaredMethods();
+    int publicMethodCount = 0;
+    for (Method method : declaredMethods) {
+      if(Modifier.isPublic(method.getModifiers())) {
+        publicMethodCount++;
+      }
+    }
+    assertThat(publicMethodCount, is(6));
   }
 
   @Test

--- a/src/test/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/session/DelegatingSessionFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/tunnel/DefaultTunnelConnectionManagerFactoryTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/tunnel/DefaultTunnelConnectionManagerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/validation/PreconditionsTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/validation/PreconditionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/hotels/hcommon/ssh/validation/validator/TunnelRouteValidatorTest.java
+++ b/src/test/java/com/hotels/hcommon/ssh/validation/validator/TunnelRouteValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This was one of the projects I was testing the latest version of the parent pom out on. I tested that the usual build targets (coverage, test, package etc.) work as expected and thought I might as well get the changes into master for future use.

